### PR TITLE
Car Shop Fix

### DIFF
--- a/levelstweakdata.lua
+++ b/levelstweakdata.lua
@@ -8,4 +8,6 @@ function LevelsTweakData:init(...)
 	self.spa.max_bags = 8
 	self.fish.max_bags = 20
 	self.vit.ghost_bonus = 0.15
+	self.cage.ghost_bonus = 0.01
+	self.cage.ghost_required = true
 end


### PR DESCRIPTION
Gives Car Shop a 1% ghost bonus to enable the "Stealth is a requirement." text in the heist's briefing. Also included the original "ghost_required" setting for safe measure.